### PR TITLE
Just some housekeeping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["tests"]
 crate-type = ["staticlib", "rlib"]
 
 [dependencies]
-num-derive = "0.3.0"
+num-derive = "0.4.0"
 num-traits = "0.2.11"
 thiserror = "1.0.19"
 

--- a/examples/qrtest.rs
+++ b/examples/qrtest.rs
@@ -50,7 +50,7 @@ fn print_result(name: &str, info: &mut ResultInfo) {
     }
 }
 
-fn add_result(mut sum: &mut ResultInfo, inf: &mut ResultInfo) {
+fn add_result(sum: &mut ResultInfo, inf: &mut ResultInfo) {
     sum.file_count += inf.file_count;
     sum.id_count += inf.id_count;
     sum.decode_count += inf.decode_count;
@@ -59,7 +59,7 @@ fn add_result(mut sum: &mut ResultInfo, inf: &mut ResultInfo) {
     sum.total_time = sum.total_time.wrapping_add(inf.total_time);
 }
 
-fn scan_file(decoder: &mut Quirc, opts: &Opts, path: &str, mut info: &mut ResultInfo) -> i32 {
+fn scan_file(decoder: &mut Quirc, opts: &Opts, path: &str, info: &mut ResultInfo) -> i32 {
     let path = PathBuf::from(path);
     let start = Instant::now();
     let total_start = start;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -420,7 +420,7 @@ fn reserved_cell(version: usize, i: i32, j: i32) -> i32 {
     0
 }
 
-fn read_bit(code: &Code, data: &mut Data, mut ds: &mut Datastream, i: i32, j: i32) {
+fn read_bit(code: &Code, data: &mut Data, ds: &mut Datastream, i: i32, j: i32) {
     let bitpos: i32 = ds.data_bits & 7;
     let bytepos: i32 = ds.data_bits >> 3;
     let mut v: i32 = grid_bit(code, j, i);
@@ -456,7 +456,7 @@ fn read_data(code: &Code, data: &mut Data, ds: &mut Datastream) {
     }
 }
 
-fn codestream_ecc(data: &mut Data, mut ds: &mut Datastream) -> Result<(), DecodeError> {
+fn codestream_ecc(data: &mut Data, ds: &mut Datastream) -> Result<(), DecodeError> {
     let ver = &VERSION_DB[data.version];
     let sb_ecc = &ver.ecc[data.ecc_level as usize];
 
@@ -493,7 +493,7 @@ fn bits_remaining(ds: &Datastream) -> i32 {
     ds.data_bits - ds.ptr
 }
 
-fn take_bits(mut ds: &mut Datastream, mut len: i32) -> i32 {
+fn take_bits(ds: &mut Datastream, mut len: i32) -> i32 {
     let mut ret: i32 = 0;
     while len != 0 && ds.ptr < ds.data_bits {
         let b: u8 = ds.data[(ds.ptr >> 3) as usize];
@@ -651,7 +651,7 @@ fn decode_kanji(data: &mut Data, ds: &mut Datastream) -> Result<(), DecodeError>
     Ok(())
 }
 
-fn decode_eci(mut data: &mut Data, ds: &mut Datastream) -> Result<(), DecodeError> {
+fn decode_eci(data: &mut Data, ds: &mut Datastream) -> Result<(), DecodeError> {
     if bits_remaining(ds) < 8 {
         return Err(DecodeError::DataUnderflow);
     }
@@ -675,7 +675,7 @@ fn decode_eci(mut data: &mut Data, ds: &mut Datastream) -> Result<(), DecodeErro
     Ok(())
 }
 
-fn decode_payload(mut data: &mut Data, ds: &mut Datastream) -> Result<(), DecodeError> {
+fn decode_payload(data: &mut Data, ds: &mut Datastream) -> Result<(), DecodeError> {
     while bits_remaining(ds) >= 4 {
         let type_0 = DataType::from_i32(take_bits(ds, 4));
         match type_0 {

--- a/src/identify.rs
+++ b/src/identify.rs
@@ -382,7 +382,7 @@ fn find_region_corners(
         Some(&find_one_corner),
         &mut psd_ref,
     );
-    let mut psd = psd_ref.into_polygon();
+    let psd = psd_ref.into_polygon();
 
     // Safe to unwrap, because the only reference was given to the call
     // to flood_fill_seed above.
@@ -980,7 +980,7 @@ fn record_qr_grid(
      * to the grid.
      */
     for cap_index in &qr.caps {
-        let mut cap = &mut capstones[*cap_index];
+        let cap = &mut capstones[*cap_index];
         rotate_capstone(cap, &h0, &hd);
         cap.qr_grid = qr_index as i32;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,6 @@ mod identify;
 mod quirc;
 mod version_db;
 
-pub use self::decode::*;
 pub use self::error::*;
 pub use self::identify::*;
 pub use self::quirc::*;

--- a/src/quirc.rs
+++ b/src/quirc.rs
@@ -179,6 +179,7 @@ pub enum EccLevel {
     Q = 3,
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for EccLevel {
     fn default() -> Self {
         EccLevel::M

--- a/tests/quircs.rs
+++ b/tests/quircs.rs
@@ -140,6 +140,7 @@ fn generated_png() {
                 }
 
                 // Known failures, same on node-quirc
+                #[allow(clippy::nonminimal_bool)]
                 if version == 23 && *ecc_level == EccLevel::Q && *mode == DataType::Numeric
                     || version == 23 && *ecc_level == EccLevel::Q && *mode == DataType::Numeric
                     || version == 23 && *ecc_level == EccLevel::Q && *mode == DataType::Kanji


### PR DESCRIPTION
It turned out that `quircs` was the only crate that depended on `syn v1` in my project so I bumped the `num-derive` to the version that depends on `syn v2` and fixed some clippy errors that came up during testing. Thanks a lot for the crate!